### PR TITLE
backport HBASE-26146: Add support for HBASE_HBCK_OPTS (#3537)

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -54,6 +54,8 @@
 #   HBASE_SHELL_OPTS Extra options passed to the hbase shell.
 #                    Empty by default.
 #
+#   HBASE_HBCK_OPTS  Extra options passed to hbck.
+#                    Defaults to HBASE_SERVER_JAAS_OPTS if specified, or HBASE_REGIONSERVER_OPTS.
 bin=`dirname "$0"`
 bin=`cd "$bin">/dev/null; pwd`
 
@@ -406,12 +408,18 @@ else
 	HBASE_OPTS="$HBASE_OPTS $CLIENT_GC_OPTS"
 fi
 
-if [ "$AUTH_AS_SERVER" == "true" ] || [ "$COMMAND" = "hbck" ]; then
-   if [ -n "$HBASE_SERVER_JAAS_OPTS" ]; then
-     HBASE_OPTS="$HBASE_OPTS $HBASE_SERVER_JAAS_OPTS"
-   else
-     HBASE_OPTS="$HBASE_OPTS $HBASE_REGIONSERVER_OPTS"
-   fi
+if [ -n "$HBASE_SERVER_JAAS_OPTS" ]; then
+  AUTH_AS_SERVER_OPTS="$HBASE_SERVER_JAAS_OPTS"
+else
+  AUTH_AS_SERVER_OPTS="$HBASE_REGIONSERVER_OPTS"
+fi
+
+if [ "$AUTH_AS_SERVER" == "true" ]; then
+  HBASE_OPTS="$HBASE_OPTS $AUTH_AS_SERVER_OPTS"
+elif [ -z "$HBASE_HBCK_OPTS" ]; then
+  # The default for hbck should be to use auth-as-server args, for compatibility
+  # with HBASE-15145
+  HBASE_HBCK_OPTS="$AUTH_AS_SERVER_OPTS"
 fi
 
 # check if the command needs jline
@@ -511,6 +519,7 @@ elif [ "$COMMAND" = "hbck" ] ; then
     CLASS='org.apache.hadoop.hbase.util.HBaseFsck'
     ;;
   esac
+  HBASE_OPTS="$HBASE_OPTS $HBASE_HBCK_OPTS"
 elif [ "$COMMAND" = "wal" ] ; then
   CLASS='org.apache.hadoop.hbase.wal.WALPrettyPrinter'
 elif [ "$COMMAND" = "hfile" ] ; then


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes https://github.com/TOSIT-IO/hbase/issues/2

#### Additional comments

Is needed for: https://github.com/TOSIT-IO/tdp-collection/pull/702

<!-- Example: "I was not sure if it is the right way to do but..." -->

See https://issues.apache.org/jira/browse/HBASE-26146
This backports enables the HBASE_HBCK_OPTS in the `hbase` startup script.
If HBASE_HBCK_OPTS is defined, it precedes any other OPTS, thus removing unwanted OPTS to be loaded in a `hbase hbck` command.

I do not know the organisation agreement on backport. I simply applied the patch found in [this PR](https://github.com/apache/hbase/pull/3537)

To test this PR:

- build Hbase using this PR
- Install (or update) a hbase installation with https://github.com/TOSIT-IO/tdp-collection/pull/702
- run `hbase hbck -j /opt/tdp/hbase/lib/hbase-hbck2-1.1.0-TDP-0.1.0-SNAPSHOT.jar` which should not raise an error and simply print usage
 
#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
